### PR TITLE
Update socketio version to 1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "request": "^2.67.0",
     "serve-index": "^1.7.2",
     "serve-static": "^1.10.0",
-    "socket.io-client": "1.3.7",
+    "socket.io-client": "1.4.0",
     "yargs": "^3.30.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "request": "^2.67.0",
     "serve-index": "^1.7.2",
     "serve-static": "^1.10.0",
-    "socket.io-client": "1.4.0",
+    "socket.io-client": "1.4.8",
     "yargs": "^3.30.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
Socket.io@1.4.0 didn't work, but 1.4.8 did. I tested it on Windows and Mac and it worked well for all 3 types of local connections.
