### PR TITLE
make proxy use https for api calls

### DIFF
--- a/cbt_tunnels.js
+++ b/cbt_tunnels.js
@@ -434,7 +434,7 @@ function cbtSocket(params) {
         clearInterval(self.drawTimeout);
         clearInterval(self.ping);
         var optionsDelete = {
-            url: 'http://'+self.tunnelapi,
+            url: 'https://'+self.tunnelapi,
             method: 'DELETE',
             headers: {
                 authorization: 'authorized '+self.auth_header

--- a/tunnel_start.js
+++ b/tunnel_start.js
@@ -94,7 +94,7 @@ var accountInfo = function(username,authkey,cb){
     console.log('Getting account info...');
     var auth = (new Buffer(username+':'+authkey)).toString('base64');
     var optionsPost = {
-        url: 'http://'+cbtUrls.node+'/api/v3/account',
+        url: 'https://'+cbtUrls.node+'/api/v3/account',
         method: 'GET',
         headers: {
             authorization: 'authorized '+auth
@@ -120,7 +120,7 @@ var postTunnel = function(username,authkey,tType,tunnelName,cb){
     console.log('POST request to CBT for a tunnel...');
     var auth = (new Buffer(username+':'+authkey)).toString('base64');
     var optionsPost = {
-        url: 'http://'+cbtUrls.node+'/api/v3/tunnels',
+        url: 'https://'+cbtUrls.node+'/api/v3/tunnels',
         method: 'POST',
         headers: {
             authorization: 'authorized '+auth
@@ -149,7 +149,7 @@ var putTunnel = function(username,authkey,params,data,cb){
     console.log('PUT request to CBT finalizing tunnel...');
     var auth = (new Buffer(username+':'+authkey)).toString('base64');
     var optionsPut = {
-        url: 'http://'+cbtUrls.node+'/api/v3/tunnels',
+        url: 'https://'+cbtUrls.node+'/api/v3/tunnels',
         followRedirect:false,
         method: 'PUT',
         headers: {


### PR DESCRIPTION
Currently all API Calls are unencrypted, which is not acceptable as they contain my credentials. I changed it to use https and it worked, so i guess the API endpoints already have ssl configured properly.